### PR TITLE
docs(runpod): pin a CUDA floor on GPU creates across every lane

### DIFF
--- a/plugins/runpod/skills/runpod-mcp/SKILL.md
+++ b/plugins/runpod/skills/runpod-mcp/SKILL.md
@@ -104,6 +104,16 @@ Structured tools, grouped by resource:
 - **Use runpodctl instead** for: **`send`/`receive`** file transfer, **SSH** key
   management, **`doctor`** setup, **model cache** — or any shell-only agent, or
   when the user wants a reproducible command.
+- **Hand the create to runpodctl (or a direct v2 POST) when the workload needs a CUDA
+  floor.** Checked 2026-09-02, no MCP tool takes a CUDA constraint: `create-pod`,
+  `create-endpoint` and `create-template` expose no `minCudaVersion` /
+  `allowedCudaVersions`, even though REST v2 has `gpu.minCudaVersion` on pod and endpoint
+  create. So an MCP-created GPU pod accepts **any** host CUDA version, and a modern image
+  can land on a host too old to run it. Re-check the live schema first — then use
+  `runpodctl pod create --min-cuda-version 12.8`, `POST /v2/pods` with
+  `gpu.minCudaVersion`, or deploy an existing template that already carries
+  `allowedCudaVersions` (the official ComfyUI templates do). Why 12.8 and when to use 13.0:
+  [`runpod-usage` gpu-selection](../runpod-usage/reference/gpu-selection.md#step-3-pin-the-cuda-floor).
 - **Hand pod creation to runpodctl** for a **multi-GPU priority list** (MCP's v2
   create-pod takes one GPU type; extra `gpuTypeIds` are dropped with a `_warning`
   on success), or for a **template + CPU** pod together — `create-pod` rejects that

--- a/plugins/runpod/skills/runpod-usage/SKILL.md
+++ b/plugins/runpod/skills/runpod-usage/SKILL.md
@@ -37,6 +37,6 @@ Read the one reference file that matches the question:
 | Build a Docker image Runpod can run (handler contract, Dockerfile, `--platform=linux/amd64`) | `reference/docker.md` |
 | **How to build an image well** — base image, layering, bake-in vs volume, pod vs serverless (queue/LB) contract | `reference/building-images.md` |
 | Where data lives — container disk vs network volume, model caching, S3 access | `reference/storage.md` |
-| Which GPU / how much VRAM / cost & availability / data centers | `reference/gpu-selection.md` |
+| Which GPU / how much VRAM / **which CUDA version** / cost & availability / data centers | `reference/gpu-selection.md` |
 | Reaching a pod or endpoint over HTTP (proxy URLs, exposed ports) | `reference/networking.md` |
 | Common mistakes and how to avoid them | `reference/gotchas.md` |

--- a/plugins/runpod/skills/runpod-usage/evals/cuda-floor-on-create.eval.md
+++ b/plugins/runpod/skills/runpod-usage/evals/cuda-floor-on-create.eval.md
@@ -1,0 +1,34 @@
+# Set a CUDA floor when creating a GPU pod
+
+## Prompt
+
+Create a Runpod GPU pod running the latest official PyTorch image on an RTX 4090 so
+I can iterate on a training script over SSH.
+
+## Expected behavior
+
+Per `runpod-usage/reference/gpu-selection.md` ("Step 3: pin the CUDA floor") and the
+`runpodctl` skill's decision rules:
+
+1. **Pins the host CUDA floor to the image's CUDA line** — the current official
+   PyTorch image is a `cu128` build, so the create carries `--min-cuda-version 12.8`
+   (or `gpu.minCudaVersion: "12.8"` on REST v2). A create with no floor accepts any
+   host, and the container then dies at startup or silently drops to CPU.
+2. **Does not jump to `13.0`** just because it's the newest — 13.0 is for a CUDA-13
+   image (`runpod/comfyui:cuda13.0`, the `cu1300` cluster PyTorch image), not for a
+   newer GPU.
+3. **Does not reach for the old default** — `runpod-torch-v21` is torch 2.1 on CUDA
+   11.8; the current default is `runpod-torch-v280`.
+4. **Uses a lane that can express the constraint** — `runpodctl pod create` or a v2
+   `POST /v2/pods`. If the agent is in the MCP lane it notes that the MCP create
+   tools carry no CUDA parameter and switches lanes (or verifies the live schema
+   before claiming otherwise).
+5. **Cost guard + SSH** as usual — `--terminate-after`, and the SSH key registered
+   before creation.
+
+## Assertions
+
+- The pod create includes a CUDA floor (`--min-cuda-version` / `gpu.minCudaVersion`), not just a GPU id.
+- The floor matches the image's CUDA line rather than defaulting to the highest number available.
+- Does not use `runpod-torch-v21` / a CUDA 11.8 image as the "latest PyTorch" default.
+- If MCP is the chosen lane, it either verifies the live tool schema or hands the create to runpodctl.

--- a/plugins/runpod/skills/runpod-usage/reference/development-loop.md
+++ b/plugins/runpod/skills/runpod-usage/reference/development-loop.md
@@ -33,8 +33,10 @@ This is the biggest lever for speed and reliability:
 
 ## 3. Plan resources
 
-GPU/VRAM (`gpu-selection.md`), storage (**default a network volume** —
-`storage.md`), and the execution lane (`../../runpod/SKILL.md` router:
+GPU/VRAM and the **CUDA floor** (`gpu-selection.md` — default
+`--min-cuda-version 12.8` on any GPU create; a create with no floor accepts any host
+CUDA version and a modern image can land on one too old to run it), storage
+(**default a network volume** — `storage.md`), and the execution lane (`../../runpod/SKILL.md` router:
 runpod-mcp / runpodctl / flash).
 
 ## 4. Provision & 5. Set up

--- a/plugins/runpod/skills/runpod-usage/reference/gotchas.md
+++ b/plugins/runpod/skills/runpod-usage/reference/gotchas.md
@@ -11,6 +11,31 @@ symptom → cause → fix. See `docker.md` and `storage.md` for the full mechani
 - **Fix:** rebuild with `docker build --platform=linux/amd64 ...` and re-push.
   This is the #1 deploy failure.
 
+## CUDA / driver mismatch — container dies at startup, or silently runs on CPU
+
+- **Symptom:** the image pulls fine but the container exits immediately with a CUDA
+  init / driver error (`CUDA driver version is insufficient for CUDA runtime version`,
+  `no kernel image is available for execution on the device`, a cuDNN load failure), or
+  it *starts* and `torch.cuda.is_available()` is `False` so everything crawls on CPU.
+  Most common on the first run of a newly created pod, and on Blackwell cards
+  (RTX 5090, RTX PRO 6000 Blackwell, B200).
+- **Cause:** the host machine's CUDA version is **older than the image was built for**.
+  A create with no CUDA constraint accepts any host, so an image built for 12.8 or 13.0
+  can be scheduled onto an older host. Nothing at create time rejects the pairing.
+- **Diagnose:** read the host's version off the pod itself — `runpodctl pod get <id>`
+  (v2 `GET /v2/pods/{id}`) returns `cudaVersion`, e.g. `"12.8"`. Compare it to the `cu`
+  tag in the image name (`…-cu1281-…` = 12.8.1, `runpod/comfyui:cuda13.0` = 13.0).
+  Host older than the image is the bug. `runpodctl pod logs <id> --source container`
+  shows the actual init error.
+- **Fix:** recreate with a floor — `runpodctl pod create … --min-cuda-version 12.8`
+  (or `gpu.minCudaVersion` on REST v2). Editing a running pod won't move it to a
+  different host. Default the floor to `12.8`; use `13.0` only for a CUDA-13 image.
+  Full rule, the `allowedCudaVersions` variant, and how to check which versions have
+  capacity: [`gpu-selection.md`](gpu-selection.md#step-3-pin-the-cuda-floor).
+- **Related trap:** picking the wrong CUDA-line *variant* of a template (the ComfyUI
+  12.8 image does not support Blackwell / CUDA 13) — see
+  `../../runpod-templates/reference/comfyui.md`.
+
 ## Using the `latest` tag
 
 - **Symptom:** you push new code but workers keep running old behavior; you can't

--- a/plugins/runpod/skills/runpod-usage/reference/gpu-selection.md
+++ b/plugins/runpod/skills/runpod-usage/reference/gpu-selection.md
@@ -1,7 +1,7 @@
 # GPU selection
 
-How to pick a GPU: size VRAM to the model first, then choose a tier/pool, then
-worry about cloud, availability, and placement.
+How to pick a GPU: size VRAM to the model first, pin the CUDA floor your image needs,
+then choose a tier/pool, then worry about cloud, availability, and placement.
 
 ## Step 1: size VRAM to the model
 
@@ -34,7 +34,60 @@ Sizes assume fp16 inference; quantize to drop a tier or two.
 | 70B | ~140 GB | 2x 80 GB, or one `HOPPER_141` (H200) / `BLACKWELL_180` (B200) |
 | > 70B | 200 GB+ | multi-GPU 80 GB+, or Blackwell / H200 with `gpu_count` > 1 |
 
-## Step 3: GPU tiers and pools
+## Step 3: pin the CUDA floor
+
+The GPU decides how much fits; the **host's CUDA version** decides whether your image
+runs on it at all. A container built against a newer CUDA than the host driver provides
+fails at startup or falls back to CPU — and nothing in a pod/endpoint create rejects the
+combination for you, so state the constraint explicitly.
+
+**Default to a floor of `12.8`.** That is the line the current official images target
+(`runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` and newer, `runpod/comfyui:cuda12.8`),
+and it is the minimum for Blackwell cards (RTX 5090, RTX PRO 6000 Blackwell, B200).
+Go to `13.0` only when the image itself is a CUDA-13 build — e.g.
+`runpod/comfyui:cuda13.0`, or the `cu1300` cluster PyTorch image — not merely because the
+GPU is new. Leave the floor off only for a CPU pod, or when you deliberately need an
+older host for an old image (a torch 2.1 / `cu118` build, say).
+
+| Lane | How to set it |
+|------|---------------|
+| `runpodctl` | `pod create --min-cuda-version 12.8` / `serverless create --min-cuda-version 12.8` (both verified against the vendored 2.10.0 command surface; `template create` has no such flag — templates carry `allowedCudaVersions` instead) |
+| REST v2 | `gpu.minCudaVersion: "12.8"` on `POST /v2/pods` and `POST /v2/serverless` |
+| flash | `min_cuda_version=CudaVersion.V12_8` — already the default (`skills/flash/reference/api.md`) |
+| Runpod MCP | The `create-pod` / `create-endpoint` tool schemas carry no CUDA parameter as of 2026-09-02 — check the live schema, and when a floor matters use `runpodctl` or post to v2 directly |
+
+### Floor vs exact set
+
+- **`minCudaVersion`** — an open-ended floor, `major.minor`, compared **numerically**, so
+  `12.11` is above `12.2`. This is what you want almost always.
+- **`allowedCudaVersions`** — an exact-match array. Anything not listed is excluded, so a
+  version no machine currently reports yields a **capacity error rather than a fallback**.
+  Reach for it only when you need to exclude a newer version too (the ComfyUI 12.8
+  template does exactly this — see `skills/runpod-templates/reference/comfyui.md`).
+- The two are **mutually exclusive** when `allowedCudaVersions` is non-empty (`400` if
+  both are sent). An explicit `[]` states "no constraint" and may accompany a floor.
+- A **template** can carry `allowedCudaVersions`, which is expanded into GPU pod and
+  endpoint creates from it. CPU pods ignore it — a CPU workload has no `gpu` block at all.
+
+### Discover what is actually available
+
+Don't guess a version — a floor set above current stock reads as "no capacity":
+
+```bash
+# per-GPU CUDA versions, each tagged with whether it has free capacity right now
+curl -s -H "Authorization: Bearer $RUNPOD_API_KEY" \
+  "https://api.runpod.io/v2/catalog/gpus?include=AVAILABILITY&product=POD&minCudaVersion=12.8"
+```
+
+`cudaVersions[]` comes back only with `include=AVAILABILITY`. The `minCudaVersion` *query*
+param accepts a bare major (`12`) unlike the create-body field; `cudaVersions` requires
+`major.minor` and is mutually exclusive with it. Use `product=SERVERLESS` when sizing an
+endpoint — the same GPU can be scarce for pods and plentiful for serverless.
+
+If the floor leaves you short on capacity, drop it one line (12.8 → 12.6) **only** if the
+image tolerates it; otherwise widen the GPU list or the region instead.
+
+## Step 4: GPU tiers and pools
 
 A **GPU pool** groups interchangeable GPUs by VRAM tier. Requesting a pool lets
 Runpod pick any available GPU in that tier (better availability); pinning an exact
@@ -66,7 +119,7 @@ in `docs/references/gpu-types.mdx`.
 Rule of thumb: prefer **fewer high-end GPUs over more low-end GPUs**. One 80 GB card
 usually beats two 40 GB cards for a model that fits.
 
-## Step 4: Secure vs Community Cloud
+## Step 5: Secure vs Community Cloud
 
 - **Secure Cloud** — T3/T4 data centers, high redundancy, stable public IPs. Use for
   production and sensitive data. Standard pricing.
@@ -74,7 +127,7 @@ usually beats two 40 GB cards for a model that fits.
   public IPs can change on migrate/restart. Good for cost-sensitive, tolerant work.
   (No new hosts are being onboarded; existing capacity remains.)
 
-## Step 5: availability and multi-GPU selection
+## Step 6: availability and multi-GPU selection
 
 `runpodctl gpu list` reports on-demand `securePricePerHr` / `communityPricePerHr` per
 GPU (explicitly `null` when that cloud doesn't offer it) plus a
@@ -98,7 +151,7 @@ GPU supply fluctuates by tier and region. To avoid throttling:
 - Use `gpu_count` > 1 (Serverless) / multi-GPU Pods when a model exceeds a single
   card's VRAM.
 
-## Step 6: data-center placement
+## Step 7: data-center placement
 
 - Restricting an endpoint or Pod to specific data centers **shrinks the available
   GPU pool** — allow all regions for maximum availability unless you have a reason

--- a/plugins/runpod/skills/runpod-usage/reference/pod-workflows.md
+++ b/plugins/runpod/skills/runpod-usage/reference/pod-workflows.md
@@ -14,6 +14,9 @@ Resolve the choices before creating anything (see `concepts.md`, `gpu-selection.
 - **Pod or serverless?** Long-lived / interactive / a persistent server → pod.
   Request/response that scales to zero → serverless (different lane).
 - **GPU / VRAM** for the workload.
+- **CUDA floor** — set `--min-cuda-version 12.8` on the create unless the image needs
+  otherwise, so a modern image can't land on a host too old to run it
+  ([`gpu-selection.md`](gpu-selection.md#step-3-pin-the-cuda-floor)).
 - **Storage** — default to a **network volume** for anything worth keeping
   (models, datasets, checkpoints, envs). See `storage.md`.
 - **Which ports** the service listens on. These must be declared **at creation**.

--- a/plugins/runpod/skills/runpod/SKILL.md
+++ b/plugins/runpod/skills/runpod/SKILL.md
@@ -155,12 +155,17 @@ moment an op needs a flag/feature MCP doesn't expose.**
 
 For any "get <X> running on Runpod" task, follow the **development loop** in
 `runpod-usage/reference/development-loop.md`: decide pod vs serverless → provision → set up
-(only if from-scratch) → verify → deliver → cost-guard + teardown. Two rules bind within it:
+(only if from-scratch) → verify → deliver → cost-guard + teardown. Three rules bind within it:
 
 - **Prefer a prebuilt template / Hub worker over building an image from scratch** —
   official pod templates are indexed in [`runpod-templates`](../runpod-templates/SKILL.md).
 - **Before delivering, verify the workload with a real request from outside the pod/endpoint
   — a "Running"/"ready" status does not mean it is serving.**
+- **Pin the CUDA floor on every GPU create** — `--min-cuda-version 12.8` by default
+  (`13.0` only for a CUDA-13 image). Without it the create accepts any host CUDA version
+  and a modern image can land on a host too old to run it, which reads as a container that
+  dies at startup or silently runs on CPU:
+  [`gpu-selection.md`](../runpod-usage/reference/gpu-selection.md#step-3-pin-the-cuda-floor).
 
 It branches to two sub-loops:
 

--- a/plugins/runpod/skills/runpodctl/SKILL.md
+++ b/plugins/runpod/skills/runpodctl/SKILL.md
@@ -46,7 +46,7 @@ runpodctl datacenter list           # GPU availability per data center (use to c
 runpodctl hub search vllm           # Find a hub repo
 runpodctl serverless create --hub-id <id> --name "my-vllm"  # Deploy from hub
 runpodctl template search pytorch   # Find a template
-runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # Create from template
+runpodctl pod create --template-id runpod-torch-v280 --gpu-id "NVIDIA GeForce RTX 4090" --min-cuda-version 12.8  # Create from template
 runpodctl pod list                  # List your pods
 ```
 
@@ -129,6 +129,14 @@ commands, `project`), and the env-var table (incl. `RUNPOD_INVOKE_URL`):
 - Use serverless for request/response inference APIs and scalable workers; use pods for interactive work, notebooks, training, debugging, or long-lived sessions.
 - Use CPU pods for preprocessing, file movement, lightweight scripts, and non-CUDA work. Use GPU pods when CUDA, model inference, training, or GPU memory is required.
 - Do not pass GPU flags when creating CPU pods. Check `runpodctl pod create --help` for the current valid flag set.
+- **Set a CUDA floor on every GPU create: `--min-cuda-version 12.8`.** It exists on both
+  `pod create` and `serverless create` (not `template create`) and it is the only thing
+  keeping a modern image off a host too old to run it — the create itself will not reject
+  the combination, the container just dies at startup or silently drops to CPU. Use `13.0`
+  only when the image is a CUDA-13 build (`runpod/comfyui:cuda13.0`, the `cu1300` cluster
+  PyTorch image), and omit it for CPU pods or a deliberately old image. Full rule, the
+  `allowedCudaVersions` exact-match variant, and how to check what has capacity:
+  [`runpod-usage` gpu-selection "pin the CUDA floor"](../runpod-usage/reference/gpu-selection.md#step-3-pin-the-cuda-floor).
 - **Waiting for a resource to be usable: use `--wait`, don't hand-roll a poll loop** (v2.9.0+). `create` returns as soon as the resource is *scheduled*, which is why a "RUNNING" pod often refuses ssh and a fresh endpoint 404s. `pod create --wait` returns when port 22 answers with an ssh banner; `serverless create --wait` when `/health` reports a ready or running worker. On timeout or ctrl-c the resource is **kept**, and its id is in the error object's `id` field — read that and clean up, don't assume nothing was created (a pod bills by the second; an endpoint with no running worker doesn't, but will start one on the first request).
 - Standing up a **service on a pod** (Ollama, ComfyUI, a dev server)? Declare its `--ports` and `--env` **at creation** (they can't be added to a running pod without a reset), then follow the pod development loop in the `runpod-usage` skill (`reference/pod-workflows.md`) — SSH-exec the install, bind to `0.0.0.0`, and poll the proxy URL until it answers.
 - For SSH, use `runpodctl pod get <pod-id>` or `runpodctl ssh info <pod-id>` to retrieve connection details. runpodctl has **no interactive-shell command** — `ssh info` returns the connection command + key but does not connect. Run commands over SSH yourself with `ssh user@host "command"`.
@@ -152,8 +160,8 @@ Essentials below. **For flags, ask the binary** — `runpodctl <resource> <actio
 ```bash
 runpodctl pod list                                   # running pods (+ --all / --status / --since / --created-after)
 runpodctl pod get <pod-id>                           # details incl. SSH info + runtimeStatus
-runpodctl pod create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090"   # from template
-runpodctl pod create --image <img> --gpu-id "NVIDIA GeForce RTX 4090"        # from image
+runpodctl pod create --template-id <id> --gpu-id "NVIDIA GeForce RTX 4090" --min-cuda-version 12.8   # from template
+runpodctl pod create --image <img> --gpu-id "NVIDIA GeForce RTX 4090" --min-cuda-version 12.8        # from image
 runpodctl pod create --compute-type cpu --image ubuntu:22.04                 # CPU pod (lowercase `cpu`; serverless uses `CPU`)
 runpodctl pod create --image <img> --gpu-id <id> --wait                      # block until ssh answers, then print the pod (v2.9.0+)
 runpodctl pod {start|stop|restart|reset|update|delete} <pod-id>              # lifecycle (delete aliases: rm/remove)
@@ -184,7 +192,7 @@ runpodctl hub get <listing-id|owner/name>            # repo details
 
 ```bash
 runpodctl serverless list | get <endpoint-id> | delete <endpoint-id>
-runpodctl serverless create --name "x" --template-id <id>       # from template
+runpodctl serverless create --name "x" --template-id <id> --min-cuda-version 12.8   # from template
 runpodctl serverless create --name "x" --hub-id <listing-id>    # from hub (+ --env KEY=VAL to override defaults)
 runpodctl serverless create --hub-id <id> --gpu-id "NVIDIA GeForce RTX 4090" \
   --model-reference https://huggingface.co/<org>/<model>:main   # attach & host-cache a HF model (GPU only)


### PR DESCRIPTION
## Problem

Nothing in the plugin tells an agent to constrain the host CUDA version when creating a GPU pod or endpoint. A create with no floor accepts **any** host, so a modern image (`cu128`, `cuda13.0`) can be scheduled onto a host too old to run it — the container dies at startup with a CUDA init error, or starts and silently runs on CPU. `comfyui.md` already calls this "the most common first-run failure," but the guidance lived only there.

Concretely, before this PR:

- `gpu-selection.md` — the file the golden loop points at for "plan resources" — had **zero** CUDA content.
- `runpodctl pod create --min-cuda-version` / `serverless create --min-cuda-version` exist but were documented in one place, framed narrowly as picking between ComfyUI template variants.
- `gotchas.md` had no CUDA-mismatch entry.
- The runpodctl quick-start example was `--template-id runpod-torch-v21` — torch 2.1 on **CUDA 11.8**, the oldest thing in the catalog.

## Change

One rule, stated once in `gpu-selection.md`, cross-linked from each lane:

| File | Change |
|---|---|
| `runpod-usage/reference/gpu-selection.md` | New **"Step 3: pin the CUDA floor"** — default `12.8`, `13.0` only for a CUDA-13 image, `minCudaVersion` vs `allowedCudaVersions`, per-lane syntax, and how to check which versions have capacity. Later steps renumbered 3→4 … 6→7. |
| `runpodctl/SKILL.md` | `--min-cuda-version 12.8` on the pod/serverless create examples; a decision rule; quick start moved off `runpod-torch-v21` to `runpod-torch-v280`. |
| `runpod-mcp/SKILL.md` | The MCP create tools carry no CUDA parameter — hand the create to runpodctl or a v2 POST when a floor matters. |
| `runpod-usage/reference/gotchas.md` | New CUDA/driver-mismatch entry: symptom, reading `cudaVersion` off the pod, fix. |
| `runpod/SKILL.md`, `development-loop.md`, `pod-workflows.md`, `runpod-usage/SKILL.md` | Cross-link the rule into the golden loop and the routing table. |
| `runpod-usage/evals/cuda-floor-on-create.eval.md` | New eval. |

## Why 12.8 and not "always the newest"

`minCudaVersion` filters host machines. A floor above current stock reads as a capacity error, not a fallback, and `allowedCudaVersions` matches exactly. So: `12.8` is the line the current official images target and the minimum for Blackwell; `13.0` is for a CUDA-13 **image**, not for a new GPU.

<details>
<summary>Verification</summary>

- `--min-cuda-version` present on `pod create` and `serverless create`, absent on `template create` — confirmed against `testdata/runpodctl/command-surface.json` (2.10.0) and live `runpodctl 2.9.0` help.
- `gpu.minCudaVersion` / `gpu.allowedCudaVersions` semantics (numeric compare, exact match, mutual exclusivity, `cudaVersions[]` under `include=AVAILABILITY`) read off `testdata/runpod-migrate/v2-openapi.json`.
- MCP `create-pod` / `create-endpoint` / `create-template` schemas inspected live 2026-09-02 — no CUDA parameter.
- All eight `hooks/*.py` validators pass locally, including `check_links.py` and `check_cli_absence_claims.py`.

</details>

## Follow-up (not in this PR)

The durable fix for the MCP gap is adding `minCudaVersion` to `create-pod`/`create-endpoint` in the runpod-mcp server; this PR only documents the workaround. Golden-path command blocks were left alone deliberately — they are live-verified transcripts.